### PR TITLE
Fix: make moveItem public and accessible from outside the class

### DIFF
--- a/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
@@ -178,7 +178,7 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
      - parameter toIndex: The index to move the item to.
      - throws: `APError.QueueError`
      */
-    func moveItem(fromIndex: Int, toIndex: Int) throws {
+    public func moveItem(fromIndex: Int, toIndex: Int) throws {
         try queueManager.moveItem(fromIndex: fromIndex, toIndex: toIndex)
     }
     


### PR DESCRIPTION
`MoveItem` was missing the `public` keyword which made the functionality inaccessible.
I tried to add tests to the Example project but I was unable to install packages for some reason.