### PR TITLE
fix(audioplayer): fix loadArtwork method to unset artwork value if no…

### DIFF
--- a/SwiftAudioEx/Classes/AudioPlayer.swift
+++ b/SwiftAudioEx/Classes/AudioPlayer.swift
@@ -300,6 +300,8 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
             if let image = image {
                 let artwork = MPMediaItemArtwork(boundsSize: image.size, requestHandler: { _ in image })
                 self.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(artwork))
+            } else {
+                self.nowPlayingInfoController.set(keyValue: MediaItemProperty.artwork(nil))
             }
         }
     }


### PR DESCRIPTION
… image is given

https://github.com/doublesymmetry/react-native-track-player/issues/1511