### PR TITLE
Allow interacting with the queue without modifying willPlayWhenReady.

### DIFF
--- a/Example/Tests/QueuedAudioPlayerTests.swift
+++ b/Example/Tests/QueuedAudioPlayerTests.swift
@@ -307,7 +307,7 @@ class QueuedAudioPlayerTests: QuickSpec {
                                     expect(audioPlayer.nextItems.count).toEventually(equal(0))
                                     expect(audioPlayer.currentIndex).toEventually(equal(1))
                                     expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.paused))
-                                    expect(eventListener.eventResult).toEventually(equal((1, nil)))
+                                    expect(eventListener.eventResult).toEventually(equal((0, 1)))
                                 }
                             }
                         }
@@ -351,7 +351,6 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.nextItems.count).toEventually(equal(1))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
                             }
                         }
 
@@ -458,7 +457,6 @@ class QueuedAudioPlayerTests: QuickSpec {
 
                                 expect(audioPlayer.nextItems.count).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.paused))
-                                expect(eventListener.eventResult).toEventually(equal((0, nil)))
                             }
                         }
 
@@ -487,7 +485,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
 
@@ -499,7 +498,6 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
                             }
                         }
                     }
@@ -521,7 +519,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
 
@@ -536,7 +535,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
                     }

--- a/SwiftAudioEx/Classes/QueueManager.swift
+++ b/SwiftAudioEx/Classes/QueueManager.swift
@@ -95,8 +95,13 @@ class QueueManager<T> {
         if (currentIndex >= index && self.items.count != 1) { currentIndex += items.count }
     }
 
-    private func skip(direction: Int, wrap: Bool) throws -> T {
-        var index = currentIndex + direction
+    internal enum SkipDirection : Int {
+        case next = 1
+        case previous = -1
+    }
+    
+    private func skip(direction: SkipDirection, wrap: Bool) throws -> T {
+        var index = currentIndex + direction.rawValue
         if (wrap) {
             index = (items.count + index) % items.count;
         }
@@ -119,7 +124,7 @@ class QueueManager<T> {
      */
     @discardableResult
     public func next(wrap: Bool = false) throws -> T {
-        return try skip(direction: 1, wrap: wrap);
+        return try skip(direction: SkipDirection.next, wrap: wrap);
     }
 
     /**
@@ -131,7 +136,7 @@ class QueueManager<T> {
      */
     @discardableResult
     public func previous(wrap: Bool = false) throws -> T {
-        return try skip(direction: -1, wrap: wrap);
+        return try skip(direction: SkipDirection.previous, wrap: wrap);
     }
 
     /**

--- a/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
@@ -12,7 +12,7 @@ import MediaPlayer
  An audio player that can keep track of a queue of AudioItems.
  */
 public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
-    
+
     let queueManager: QueueManager = QueueManager<AudioItem>()
 
     public override init(nowPlayingInfoController: NowPlayingInfoControllerProtocol = NowPlayingInfoController(), remoteCommandController: RemoteCommandController = RemoteCommandController()) {
@@ -22,18 +22,18 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
 
     /// The repeat mode for the queue player.
     public var repeatMode: RepeatMode = .off
-    
+
     public override var currentItem: AudioItem? {
         queueManager.current
     }
-    
+
     /**
      The index of the current item.
      */
     public var currentIndex: Int {
         queueManager.currentIndex
     }
-    
+
      /**
      Stops the player and clears the queue.
      */
@@ -41,149 +41,140 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
         super.stop()
         event.queueIndex.emit(data: (currentIndex, nil))
     }
-    
+
     override func reset() {
         super.reset()
         queueManager.clearQueue()
     }
-    
+
     /**
      All items currently in the queue.
      */
     public var items: [AudioItem] {
         queueManager.items
     }
-    
+
     /**
      The previous items held by the queue.
      */
     public var previousItems: [AudioItem] {
         queueManager.previousItems
     }
-    
+
     /**
      The upcoming items in the queue.
      */
     public var nextItems: [AudioItem] {
         queueManager.nextItems
     }
-    
+
     /**
      Will replace the current item with a new one and load it into the player.
-     
+
      - parameter item: The AudioItem to replace the current item.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: APError.LoadError
      */
-    public override func load(item: AudioItem, playWhenReady: Bool) throws {
-        try super.load(item: item, playWhenReady: playWhenReady)
+    public override func load(item: AudioItem, playWhenReady: Bool? = nil) throws {
+        try super.load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         queueManager.replaceCurrentItem(with: item)
     }
-    
+
     /**
      Add a single item to the queue.
-     
+
      - parameter item: The item to add.
-     - parameter playWhenReady: If the AudioPlayer has no item loaded, it will load the `item`. If this is `true` it will automatically start playback. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func add(item: AudioItem, playWhenReady: Bool = true) throws {
+    public func add(item: AudioItem, playWhenReady: Bool? = nil) throws {
         if currentItem == nil {
             queueManager.addItem(item)
-            try load(item: item, playWhenReady: playWhenReady)
+            try load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
         else {
             queueManager.addItem(item)
         }
     }
-    
+
     /**
      Add items to the queue.
-     
+
      - parameter items: The items to add to the queue.
-     - parameter playWhenReady: If the AudioPlayer has no item loaded, it will load the first item in the list. If this is `true` it will automatically start playback. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func add(items: [AudioItem], playWhenReady: Bool = true) throws {
+    public func add(items: [AudioItem], playWhenReady: Bool? = nil) throws {
         if currentItem == nil {
             queueManager.addItems(items)
-            try load(item: currentItem!, playWhenReady: playWhenReady)
+            try load(item: currentItem!, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
         else {
             queueManager.addItems(items)
         }
     }
-    
+
     public func add(items: [AudioItem], at index: Int) throws {
         try queueManager.addItems(items, at: index)
     }
-    
+
     /**
      Step to the next item in the queue.
-     
+
      - throws: `APError`
      */
     public func next() throws {
-        let shouldPlayWhenReady = (playerState == .loading) ? willPlayWhenReady : [.buffering, .playing].contains(playerState)
-
-        do {
-            let nextItem = try queueManager.next()
-            event.playbackEnd.emit(data: .skippedToNext)
-            try load(item: nextItem, playWhenReady: shouldPlayWhenReady)
-        } catch APError.QueueError.noNextItem  {
-            if repeatMode == .queue {
-                event.playbackEnd.emit(data: .skippedToNext)
-                try jumpToItem(atIndex: 0, playWhenReady: shouldPlayWhenReady)
-            } else {
-                throw APError.QueueError.noNextItem
-            }
-        } catch {
-            throw error
-        }
+        let item = try queueManager.next(wrap: repeatMode == .queue)
+        event.playbackEnd.emit(data: .skippedToNext)
+        try load(item: item)
     }
-    
+
     /**
      Step to the previous item in the queue.
      */
     public func previous() throws {
-        let shouldPlayWhenReady = (playerState == .loading) ? willPlayWhenReady : [.buffering, .playing].contains(playerState)
-
-        let previousItem = try queueManager.previous()
+        let item = try queueManager.previous(wrap: repeatMode == .queue)
         event.playbackEnd.emit(data: .skippedToPrevious)
-        try load(item: previousItem, playWhenReady: shouldPlayWhenReady)
+        try load(item: item)
     }
-    
+
     /**
      Remove an item from the queue.
-     
+
      - parameter index: The index of the item to remove.
      - throws: `APError.QueueError`
      */
     public func removeItem(at index: Int) throws {
         try queueManager.removeItem(at: index)
     }
-    
+
+
     /**
      Jump to a certain item in the queue.
-     
+
      - parameter index: The index of the item to jump to.
-     - parameter playWhenReady: Wether the item should start playing when ready. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func jumpToItem(atIndex index: Int, playWhenReady: Bool = true) throws {
+    public func jumpToItem(atIndex index: Int, playWhenReady: Bool? = nil) throws {
         if (index == currentIndex) {
             seek(to: 0)
-            playWhenReady ? play() : pause()
+            if (playWhenReady == true) {
+                play()
+            } else if (playWhenReady == false) {
+                pause()
+            }
             onCurrentIndexChanged(oldIndex: index, newIndex: index)
         } else {
             let item = try queueManager.jump(to: index)
             event.playbackEnd.emit(data: .jumpedToIndex)
-            try load(item: item, playWhenReady: playWhenReady)
+            try load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
     }
-    
+
     /**
      Move an item in the queue from one position to another.
-     
+
      - parameter fromIndex: The index of the item to move.
      - parameter toIndex: The index to move the item to.
      - throws: `APError.QueueError`
@@ -191,43 +182,31 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
     public func moveItem(fromIndex: Int, toIndex: Int) throws {
         try queueManager.moveItem(fromIndex: fromIndex, toIndex: toIndex)
     }
-    
+
     /**
      Remove all upcoming items, those returned by `next()`
      */
     public func removeUpcomingItems() {
         queueManager.removeUpcomingItems()
     }
-    
+
     /**
      Remove all previous items, those returned by `previous()`
      */
     public func removePreviousItems() {
         queueManager.removePreviousItems()
     }
-    
+
     // MARK: - AVPlayerWrapperDelegate
-    
+
     override func AVWrapperItemDidPlayToEndTime() {
         super.AVWrapperItemDidPlayToEndTime()
-
-        switch repeatMode {
-        case .off:
-            do {
-                let nextItem = try queueManager.next()
-                try load(item: nextItem, playWhenReady: true)
-            } catch {
-                event.queueIndex.emit(data: (currentIndex, nil))
-            }
-        case .track:
-            try? jumpToItem(atIndex: currentIndex, playWhenReady: true)
-        case .queue:
-            do {
-                let nextItem = try queueManager.next()
-                try load(item: nextItem, playWhenReady: true)
-            } catch {
-                try? jumpToItem(atIndex: 0, playWhenReady: true)
-            }
+        if (repeatMode == .track) {
+            seek(to: 0);
+            play()
+        } else {
+            guard let item = try? queueManager.next(wrap: repeatMode == .queue) else { return }
+            try? load(item: item)
         }
     }
 


### PR DESCRIPTION
See https://github.com/doublesymmetry/react-native-track-player/issues/1691

- Make `playWhenReady` optional defaulting to `willPlayWhenReady` in `QueuedAudioPlayer#load`, `QueuedAudioPlayer#add`, `QueuedAudioPlayer#jump` & `AudioPlayer#load`
- stop `QueuedAudioPlayer#next` and `QueuedAudioPlayer#previous` from (wrongly) mutating `playWhenReady`
- avoid catch logic in `QueuedAudioPlayer#AVWrapperItemDidPlayToEndTime`,  `QueuedAudioPlayer#next()` & `QueuedAudioPlayer#previous()` by adding (optional) wrap parameter to `QueueManager#next` and `QueueManager#previous`
- introduce private `skip` helper to `QueueManager` for use in `QueueManager#next` and `QueueManager#previous`