### PR TITLE
Feature/queue improvements

### DIFF
--- a/Example/SwiftAudio/AudioController.swift
+++ b/Example/SwiftAudio/AudioController.swift
@@ -36,7 +36,8 @@ class AudioController {
             .changePlaybackPosition
         ]
         try? audioSessionController.set(category: .playback)
-        try? player.add(items: sources, playWhenReady: false)
+        player.repeatMode = .queue
+        try? player.add(items: sources)
     }
     
 }

--- a/Example/SwiftAudio/ViewController.swift
+++ b/Example/SwiftAudio/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController {
         if lastLoadFailed, let item = controller.player.currentItem {
             lastLoadFailed = false
             errorLabel.isHidden = true
-            try? controller.player.load(item: item, playWhenReady: true)
+            controller.player.load(item: item, playWhenReady: true)
         }
         else {
             controller.player.togglePlaying()
@@ -95,7 +95,7 @@ class ViewController: UIViewController {
     }
     
     func setPlayButtonState(forAudioPlayerState state: AudioPlayerState) {
-        playButton.setTitle(state == .playing ? "Pause" : "Play", for: .normal)
+        playButton.setTitle(state == .paused ? "Play" : "Pause", for: .normal)
     }
     
     func setErrorMessage(_ message: String) {

--- a/Example/Tests/QueueManagerTests.swift
+++ b/Example/Tests/QueueManagerTests.swift
@@ -14,58 +14,65 @@ class QueueManagerTests: QuickSpec {
         
         describe("A QueueManager") {
             
-            var manager: QueueManager<Int>!
+            var queue: QueueManager<Int>!
             
             beforeEach {
-                manager = QueueManager()
+                queue = QueueManager()
             }
             
             describe("its current item") {
                 
-                it("should be nil") {
-                    expect(manager.current).to(beNil())
+                it("should be nil starting out") {
+                    expect(queue.current).to(beNil())
                 }
                 
                 context("when one item is added") {
                     beforeEach {
-                        manager.addItem(self.dummyItem)
+                        queue.add(self.dummyItem)
                     }
                     
-                    it("should not be nil") {
-                        expect(manager.current).toNot(beNil())
+                    it("should be nil, because it wasn't jumped to") {
+                        expect(queue.current).to(beNil())
                     }
-                    
-                    it("should be the added item") {
-                        expect(manager.current).to(equal(self.dummyItem))
-                    }
-                    
-                    context("then replaced") {
+
+                    context("after being jumped to") {
                         beforeEach {
-                            manager.replaceCurrentItem(with: 1)
+                            try! queue.jump(to: 0)
                         }
-                        it("should be the new item") {
-                            expect(manager.current).to(equal(1))
+                    
+                        it("should be the added item") {
+                            expect(queue.current).to(equal(self.dummyItem))
+                        }
+                        
+                        context("then replaced") {
+                            beforeEach {
+                                queue.replaceCurrentItem(with: 1)
+                            }
+                            it("should be the new item") {
+                                expect(queue.current).to(equal(1))
+                            }
                         }
                     }
                 }
                 
-                context("when replaced") {
+                context("when replacing the current item when the queue is still empty") {
                     beforeEach {
-                        manager.replaceCurrentItem(with: 1)
+                        queue.replaceCurrentItem(with: 1)
                     }
                     
-                    it("should not be nil") {
-                        expect(manager.current).toNot(beNil())
+                    it("the current item should be the replaced item") {
+                        expect(queue.current).toNot(beNil())
                     }
                 }
                 
-                context("when mulitple items are added") {
+                context("when multiple items are added and the last is jumped to") {
                     beforeEach {
-                        manager.addItems(self.dummyItems)
+                        queue.add(self.dummyItems)
+                        try! queue.jump(to: queue.items.count - 1)
                     }
                     
                     it("should not be nil") {
-                        expect(manager.current).toNot(beNil())
+                        expect(queue.current).toNot(beNil())
                     }
                 }
                 
@@ -73,90 +80,123 @@ class QueueManagerTests: QuickSpec {
 
             describe("when adding at index") {
                 context("adding item at index 0 when queue is empty") {
+                    beforeEach {
+                        try! queue.add([3], at: 0)
+                    }
                     it("should add element successfully") {
-                        try manager.addItems([3], at: 0)
-                        expect(manager.current).to(equal(3))
+                        expect(queue.items.first).to(equal(3))
+                    }
+                    it("should not set currentItem") {
+                        expect(queue.current).to(beNil())
+                    }
+                    it("should not set currentIndex") {
+                        expect(queue.currentIndex).to(equal(-1))
                     }
                 }
 
-                context("adding item at index") {
+                context("adding item at index and jumping to the first item") {
                     beforeEach {
-                        manager.addItems([3, 1])
+                        queue.add([1, 2])
+                        try! queue.jump(to: 0)
                     }
 
-                    context("current [element count]") {
+                    context("adding item at current [element count]") {
                         it("should add element successfully") {
-                            try manager.addItems([5], at: manager.items.count)
-                            expect(manager.items.last).to(equal(5))
+                            try queue.add([3, 4, 5], at: queue.items.count)
+                            expect(queue.items.last).to(equal(5))
+                        }
+
+                        context("before the first item") {
+                            it("should add element successfully") {
+                                try queue.add([-1], at: 0)
+                                expect(queue.items.first).to(equal(-1))
+                            }
+                        }
+
+                        context("after the last item") {
+                            it("should add element successfully") {
+                                try queue.add([6], at: queue.items.count)
+                                expect(queue.items.last).to(equal(6))
+                            }
                         }
                     }
 
-                    context("before the [current index]") {
-                        it("should add element successfully") {
-                            try manager.addItems([5], at: 0)
-                            expect(manager.current).to(equal(3))
-                            expect(manager.currentIndex).to(equal(1))
+                    context("calling next, causing currentIndex to become 1, then adding at index 1") {
+                        beforeEach {
+                            try! queue.next()
+                            try! queue.add([5], at: queue.currentIndex)
                         }
-                    }
-
-                    context("after the [current index]") {
-                        it("should add element successfully") {
-                            try manager.addItems([5], at: 1)
-                            expect(manager.current).to(equal(3))
-                            expect(manager.currentIndex).to(equal(0))
-                        }
-                    }
-
-                    context("at [current index]") {
-                        it("should add element successfully") {
-                            try manager.next()
-                            try manager.addItems([5], at: 1)
-                            expect(manager.current).to(equal(1))
-                            expect(manager.currentIndex).to(equal(2))
+                        it("should cause the current item to be shifted to index 2") {
+                            expect(queue.current).to(equal(2))
+                            expect(queue.currentIndex).to(equal(2))
                         }
                     }
                 }
             }
             
-            context("when adding one item") {
+            context("when adding one item but not jumping to it yet") {
                 
                 beforeEach {
-                    manager.addItem(self.dummyItem)
+                    queue.add(0)
                 }
                 
                 it("should have an item in the queue") {
-                    expect(manager.items).notTo(beEmpty())
+                    expect(queue.items.count).to(equal(1))
                 }
                 
                 context("then replacing the item") {
                     beforeEach {
-                        manager.replaceCurrentItem(with: 1)
+                        queue.replaceCurrentItem(with: 1)
                     }
-                    it("should have replaced the current item") {
-                        expect(manager.current).to(equal(1))
+                    it("should have added an item and jumped to it") {
+                        expect(queue.current).to(equal(1))
+                        expect(queue.currentIndex).to(equal(1))
                     }
                 }
                 
                 context("then calling next") {
-                    
-                    var nextItem: Int?
-                    
+                    var error: Error?
+                    var item: Int?
                     beforeEach {
-                        nextItem = try? manager.next()
+                        do {
+                            item = try queue.next()
+                        }
+                        catch let err {
+                            error = err
+                        }
                     }
                     
-                    it("should not return") {
-                        expect(nextItem).to(beNil())
+                    it("should throw, because there was no currentItem") {
+                        expect(error).toNot(beNil())
+                        expect(item).to(beNil())
                     }
-                    
                 }
 
-                context("then calling next(wrap: true)") {
+                context("then calling previous") {
+                    var error: Error?
+                    var item: Int?
+                    beforeEach {
+                        do {
+                            item = try queue.previous()
+                        }
+                        catch let err {
+                            error = err
+                        }
+                    }
+                    
+                    it("should throw, because there was no currentItem") {
+                        expect(error).toNot(beNil())
+                        expect(item).to(beNil())
+                    }
+                }
+                
+                context("then jumping to 0 and calling next(wrap: true)") {
                     
                     var nextIndex: Int?
                     
                     beforeEach {
-                        nextIndex = try! manager.next(wrap: true)
+                        try! queue.jump(to: 0)
+                        nextIndex = try! queue.next(wrap: true)
                     }
                     
                     it("should wrap to itself") {
@@ -165,11 +205,12 @@ class QueueManagerTests: QuickSpec {
 
                 }
                 
-                context("then calling previous(wrap: true") {
+                context("then jumping to 0 and then calling previous(wrap: true") {
                     var previousIndex: Int?
                     
                     beforeEach {
-                        previousIndex = try? manager.previous(wrap: true)
+                        try! queue.jump(to: 0)
+                        previousIndex = try? queue.previous(wrap: true)
                     }
                     
                     it("should wrap to itself") {
@@ -182,406 +223,429 @@ class QueueManagerTests: QuickSpec {
             context("when adding multiple items") {
                 
                 beforeEach {
-                    manager.addItems(self.dummyItems)
+                    queue.add([0, 1, 2, 3, 4, 5, 6])
                 }
                 
                 it("should have items in the queue") {
-                    expect(manager.items.count).to(equal(self.dummyItems.count))
+                    expect(queue.items.count).to(equal(7))
                 }
                 
-                it("should have the first item as a current item") {
-                    expect(manager.current).toNot(beNil())
-                    expect(manager.current).to(equal(self.dummyItems.first))
+                it("the current item should be nil") {
+                    expect(queue.current).to(beNil())
                 }
                 
-                it("should have next items") {
-                    expect(manager.nextItems).toNot(beNil())
-                    expect(manager.nextItems.count).to(equal(self.dummyItems.count - 1))
+                it("should not have next items") {
+                    expect(queue.nextItems.count).to(equal(0))
                 }
                 
-                context("then calling next") {
-                    var nextItem: Int?
+                context("when jumping to first item") {
                     beforeEach {
-                        nextItem = try? manager.next()
+                        try! queue.jump(to: 0)
                     }
-                    
-                    it("should return the next item") {
-                        expect(nextItem).toNot(beNil())
-                        expect(nextItem).to(equal(self.dummyItems[1]))
-                    }
-                    
-                    it("should have next current item") {
-                        expect(manager.current).to(equal(self.dummyItems[1]))
-                    }
-                    
-                    it("should have previous items") {
-                        expect(manager.previousItems).toNot(beNil())
-                    }
-                                        
-                    context("then calling previous") {
-                        var index: Int?
+                    context("then calling next") {
+                        var nextItem: Int?
                         beforeEach {
-                            index = try? manager.previous()
+                            nextItem = try? queue.next()
                         }
-                        it("should return the first item") {
-                            expect(index).to(equal(0))
+                        
+                        it("should return the next item") {
+                            expect(nextItem).toNot(beNil())
+                            expect(nextItem).to(equal(self.dummyItems[1]))
                         }
-                        it("should have the previous current item") {
-                            expect(manager.current).to(equal(self.dummyItems.first))
+                        
+                        it("should have next current item") {
+                            expect(queue.current).to(equal(self.dummyItems[1]))
                         }
-                        context("then calling previous at the start of the queue") {
+                        
+                        it("should have previous items") {
+                            expect(queue.previousItems).toNot(beNil())
+                        }
+                                            
+                        context("then calling previous") {
                             var index: Int?
                             beforeEach {
-                                index = try? manager.previous()
+                                index = try? queue.previous()
                             }
-                            it("should return nil because an error was thrown") {
-                                expect(index).to(beNil())
+                            it("should return the first item") {
+                                expect(index).to(equal(0))
                             }
-                        }
-                        context("then calling previous(wrap: true)") {
-                            var index: Int?
-                            beforeEach {
-                                index = try? manager.previous(wrap: true)
+                            it("should have the previous current item") {
+                                expect(queue.current).to(equal(self.dummyItems.first))
                             }
-                            it("should return the last item") {
-                                expect(index).to(equal(manager.items.count - 1))
-                                expect(manager.currentIndex).to(equal(manager.items.count - 1))
-                                expect(manager.current).to(equal(self.dummyItems.last))
-                            }
-
-                            context("then calling next again at the end of the queue") {
+                            context("then calling previous at the start of the queue") {
                                 var index: Int?
                                 beforeEach {
-                                    index = try? manager.next()
+                                    index = try? queue.previous()
                                 }
                                 it("should return nil because an error was thrown") {
                                     expect(index).to(beNil())
                                 }
                             }
-
-                            context("then calling next(wrap: true)") {
+                            context("then calling previous(wrap: true)") {
                                 var index: Int?
                                 beforeEach {
-                                    index = try? manager.next(wrap: true)
+                                    index = try? queue.previous(wrap: true)
                                 }
-                                it("should return the first item") {
-                                    expect(index).to(equal(0))
-                                    expect(manager.currentIndex).to(equal(0))
-                                    expect(manager.current).to(equal(self.dummyItems.first))
+                                it("should return the last item") {
+                                    expect(index).to(equal(queue.items.count - 1))
+                                    expect(queue.currentIndex).to(equal(queue.items.count - 1))
+                                    expect(queue.current).to(equal(self.dummyItems.last))
                                 }
+
+                                context("then calling next again at the end of the queue") {
+                                    var index: Int?
+                                    beforeEach {
+                                        index = try? queue.next()
+                                    }
+                                    it("should return nil because an error was thrown") {
+                                        expect(index).to(beNil())
+                                    }
+                                }
+
+                                context("then calling next(wrap: true)") {
+                                    var index: Int?
+                                    beforeEach {
+                                        index = try? queue.next(wrap: true)
+                                    }
+                                    it("should return the first item") {
+                                        expect(index).to(equal(0))
+                                        expect(queue.currentIndex).to(equal(0))
+                                        expect(queue.current).to(equal(self.dummyItems.first))
+                                    }
+                                }
+                            }
+                        }
+                        
+                        context("then removing previous items") {
+                            beforeEach {
+                                queue.removePreviousItems()
+                            }
+                            it("should have no previous items") {
+                                expect(queue.previousItems.count).to(equal(0))
+                            }
+                            it("should have current index zero") {
+                                expect(queue.currentIndex).to(equal(0))
+                            }
+                        }
+                    }
+                
+                    context("adding more items") {
+                        var initialItemCount: Int!
+                        let newItems: [Int] = [10, 11, 12, 13]
+                        beforeEach {
+                            initialItemCount = queue.items.count
+                            try? queue.add(newItems, at: queue.items.endIndex - 1)
+                        }
+                        
+                        it("should have more items") {
+                            expect(queue.items.count).to(equal(initialItemCount + newItems.count))
+                        }
+                    }
+                    
+                    context("adding more items at a smaller index than currentIndex") {
+                        var initialCurrentIndex: Int!
+                        let newItems: [Int] = [10, 11, 12, 13]
+                        beforeEach {
+                            initialCurrentIndex = queue.currentIndex
+                            try? queue.add(newItems, at: initialCurrentIndex)
+                        }
+                        
+                        it("currentIndex should increase by number of new items") {
+                            expect(queue.currentIndex).to(equal(initialCurrentIndex + newItems.count))
+                        }
+                    }
+                    
+                    // MARK: - Removal
+                    
+                    context("then removing a item with index less than currentIndex") {
+                        beforeEach {
+                            var removed: Int?
+                            var initialCurrentIndex: Int!
+                            beforeEach {
+                                let _ = try? queue.jump(to: 3)
+                                initialCurrentIndex = queue.currentIndex
+                                removed = try? queue.removeItem(at: initialCurrentIndex - 1)
+                            }
+                            
+                            it("should remove an item") {
+                                expect(removed).toNot(beNil())
+                            }
+                            
+                            it("should decrement the currentIndex") {
+                                expect(queue.currentIndex).to(equal(initialCurrentIndex - 1))
                             }
                         }
                     }
                     
-                    context("then removing previous items") {
-                        beforeEach {
-                            manager.removePreviousItems()
-                        }
-                        it("should have no previous items") {
-                            expect(manager.previousItems.count).to(equal(0))
-                        }
-                        it("should have current index zero") {
-                            expect(manager.currentIndex).to(equal(0))
-                        }
-                    }
-                }
-                
-                context("adding more items") {
-                    var initialItemCount: Int!
-                    let newItems: [Int] = [10, 11, 12, 13]
-                    beforeEach {
-                        initialItemCount = manager.items.count
-                        try? manager.addItems(newItems, at: manager.items.endIndex - 1)
-                    }
-                    
-                    it("should have more items") {
-                        expect(manager.items.count).to(equal(initialItemCount + newItems.count))
-                    }
-                }
-                
-                context("adding more items at a smaller index than currentIndex") {
-                    var initialCurrentIndex: Int!
-                    let newItems: [Int] = [10, 11, 12, 13]
-                    beforeEach {
-                        initialCurrentIndex = manager.currentIndex
-                        try? manager.addItems(newItems, at: initialCurrentIndex)
-                    }
-                    
-                    it("currentIndex should increase by number of new items") {
-                        expect(manager.currentIndex).to(equal(initialCurrentIndex + newItems.count))
-                    }
-                }
-                
-                // MARK: - Removal
-                
-                context("then removing a item with index less than currentIndex") {
-                    beforeEach {
+                    context("then removing the second item") {
                         var removed: Int?
-                        var initialCurrentIndex: Int!
                         beforeEach {
-                            let _ = try? manager.jump(to: 3)
-                            initialCurrentIndex = manager.currentIndex
-                            removed = try? manager.removeItem(at: initialCurrentIndex - 1)
+                            removed = try? queue.removeItem(at: 1)
                         }
                         
-                        it("should remove an item") {
+                        it("should have one less item") {
                             expect(removed).toNot(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count - 1))
+                        }
+                    }
+                    
+                    context("then removing the last item") {
+                        var removed: Int?
+                        beforeEach {
+                            removed = try? queue.removeItem(at: self.dummyItems.count - 1)
                         }
                         
-                        it("should decrement the currentIndex") {
-                            expect(manager.currentIndex).to(equal(initialCurrentIndex - 1))
+                        it("should have one less item") {
+                            expect(removed).toNot(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count - 1))
                         }
                     }
-                }
-                
-                context("then removing the second item") {
-                    var removed: Int?
-                    beforeEach {
-                        removed = try? manager.removeItem(at: 1)
-                    }
                     
-                    it("should have one less item") {
-                        expect(removed).toNot(beNil())
-                        expect(manager.items.count).to(equal(self.dummyItems.count - 1))
-                    }
-                }
-                
-                context("then removing the last item") {
-                    var removed: Int?
-                    beforeEach {
-                        removed = try? manager.removeItem(at: self.dummyItems.count - 1)
-                    }
-                    
-                    it("should have one less item") {
-                        expect(removed).toNot(beNil())
-                        expect(manager.items.count).to(equal(self.dummyItems.count - 1))
-                    }
-                }
-                
-                context("then removing the current item") {
-                    var removed: Int?
-                    beforeEach {
-                        removed = try? manager.removeItem(at: manager.currentIndex)
-                    }
-                    it("should not remove any items") {
-                        expect(removed).to(beNil())
-                        expect(manager.items.count).to(equal(self.dummyItems.count))
-                    }
-                }
-                
-                context("then removing with too large index") {
-                    var removed: Int?
-                    beforeEach {
-                        removed = try? manager.removeItem(at: self.dummyItems.count)
+                    context("then removing the current item when it is the first item") {
+                        var removed: Int?
+                        beforeEach {
+                            removed = try? queue.removeItem(at: queue.currentIndex)
+                        }
+                        it("should remove the current item") {
+                            expect(removed).toNot(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count - 1))
+                            expect(queue.currentIndex).to(equal(-1))
+                            expect(queue.current).to(beNil())
+                        }
                     }
 
-                    it("should not remove any items") {
-                        expect(removed).to(beNil())
-                        expect(manager.items.count).to(equal(self.dummyItems.count))
-                    }
-                }
-                
-                context("then removing with too small index") {
-                    var removed: Int?
-                    beforeEach {
-                        removed = try? manager.removeItem(at: -1)
-                    }
-                    
-                    it("should not remove any items") {
-                        expect(removed).to(beNil())
-                        expect(manager.items.count).to(equal(self.dummyItems.count))
-                    }
-                }
-                
-                context("then removing upcoming items") {
-                    beforeEach {
-                        manager.removeUpcomingItems()
-                    }
-                    
-                    it("should have no next items") {
-                        expect(manager.nextItems.count).to(equal(0))
-                    }
-                }
-                
-                // MARK: - Jumping
-                
-                context("then jumping to the current item") {
-                    var error: Error?
-                    var item: Int?
-                    beforeEach {
-                        do {
-                            item = try manager.jump(to: manager.currentIndex)
+                    context("then removing the current item when it is the last item") {
+                        var removed: Int?
+                        beforeEach {
+                            try! queue.jump(to: queue.items.count - 1);
+                            removed = try? queue.removeItem(at: queue.currentIndex)
                         }
-                        catch let err {
-                            error = err
+                        it("should remove the current item") {
+                            expect(removed).toNot(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count - 1))
+                            expect(queue.currentIndex).to(equal(-1))
+                        }
+
+                    }
+
+                    context("then removing with too large index") {
+                        var removed: Int?
+                        beforeEach {
+                            removed = try? queue.removeItem(at: self.dummyItems.count)
+                        }
+
+                        it("should not remove any items") {
+                            expect(removed).to(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count))
                         }
                     }
                     
-                    it("should not return an item") {
-                        expect(item).to(beNil())
-                    }
-                    
-                    it("should throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("then jumping to the second item") {
-                    var jumped: Int?
-                    beforeEach {
-                        try? jumped = manager.jump(to: 1)
-                    }
-                    
-                    it("should return the current item") {
-                        expect(jumped).toNot(beNil())
-                        expect(jumped).to(equal(manager.current))
-                    }
-                    
-                    it("should move the current index") {
-                        expect(manager.currentIndex).to(equal(1))
-                    }
-                }
-                
-                context("then jumping to last item") {
-                    var jumped: Int?
-                    beforeEach {
-                        try? jumped = manager.jump(to: manager.items.count - 1)
-                    }
-                    it("should return the current item") {
-                        expect(jumped).toNot(beNil())
-                        expect(jumped).to(equal(manager.current))
-                    }
-                    
-                    it("should move the current index") {
-                        expect(manager.currentIndex).to(equal(manager.items.count - 1))
-                    }
-                }
-                
-                context("then jumping to a negative index") {
-                    var jumped: Int?
-                    beforeEach {
-                        jumped = try? manager.jump(to: -1)
-                    }
-                    
-                    it("should not return") {
-                        expect(jumped).to(beNil())
-                    }
-                    
-                    it("should not move the current index") {
-                        expect(manager.currentIndex).to(equal(0))
-                    }
-                }
-                
-                context("then jumping with too large index") {
-                    var jumped: Int?
-                    beforeEach {
-                        jumped = try? manager.jump(to: manager.items.count)
-                    }
-                    it("should not return") {
-                        expect(jumped).to(beNil())
-                    }
-                    
-                    it("should not move the current index") {
-                        expect(manager.currentIndex).to(equal(0))
-                    }
-                }
-                
-                // MARK: - Moving
-                
-                context("moving from current index") {
-                    var error: Error?
-                    beforeEach {
-                        do {
-                            try manager.moveItem(fromIndex: manager.currentIndex, toIndex: manager.currentIndex + 1)
+                    context("then removing with too small index") {
+                        var removed: Int?
+                        beforeEach {
+                            removed = try? queue.removeItem(at: -1)
                         }
-                        catch let err { error = err }
-                    }
-                    
-                    it("throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("moving from a negative index") {
-                    var error: Error?
-                    beforeEach {
-                        do {
-                            try manager.moveItem(fromIndex: -1, toIndex: manager.currentIndex + 1)
+                        
+                        it("should not remove any items") {
+                            expect(removed).to(beNil())
+                            expect(queue.items.count).to(equal(self.dummyItems.count))
                         }
-                        catch let err { error = err }
                     }
                     
-                    it("should throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("moving from a too large index") {
-                    var error: Error?
-                    beforeEach {
-                        do {
-                            try manager.moveItem(fromIndex: manager.items.count, toIndex: manager.currentIndex + 1)
+                    context("then removing upcoming items") {
+                        beforeEach {
+                            queue.removeUpcomingItems()
                         }
-                        catch let err { error = err }
-                    }
-                    
-                    it("should throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("moving to a negative index") {
-                    var error: Error?
-                    beforeEach {
-                        do {
-                            try manager.moveItem(fromIndex: manager.currentIndex + 1, toIndex: -1)
+                        
+                        it("should have no next items") {
+                            expect(queue.nextItems.count).to(equal(0))
                         }
-                        catch let err { error = err }
                     }
                     
-                    it("should throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("moving to a too large index") {
-                    var error: Error?
-                    beforeEach {
-                        do {
-                            try manager.moveItem(fromIndex: manager.currentIndex + 1, toIndex: manager.items.count)
+                    // MARK: - Jumping
+                    
+                    context("then jumping to the current item") {
+                        var error: Error?
+                        var item: Int?
+                        beforeEach {
+                            do {
+                                item = try queue.jump(to: queue.currentIndex)
+                            }
+                            catch let err {
+                                error = err
+                            }
                         }
-                        catch let err { error = err }
+                        
+                        it("should return an item") {
+                            expect(item).toNot(beNil())
+                        }
+                        
+                        it("should not throw an error") {
+                            expect(error).to(beNil())
+                        }
                     }
                     
-                    it("should throw an error") {
-                        expect(error).toNot(beNil())
-                    }
-                }
-                
-                context("then moving 2nd to 4th") {
-                    let afterMoving: [Int] = [0, 2, 3, 1, 4, 5, 6]
-                    beforeEach {
-                        try? manager.moveItem(fromIndex: 1, toIndex: 3)
-                    }
-                    
-                    it("should move the item") {
-                        expect(manager.items).to(equal(afterMoving))
-                    }
-                }
-                
-                // MARK: - Clear
-                
-                context("when queue is cleared") {
-                    beforeEach {
-                        manager.clearQueue()
+                    context("then jumping to the second item") {
+                        var jumped: Int?
+                        beforeEach {
+                            try? jumped = queue.jump(to: 1)
+                        }
+                        
+                        it("should return the current item") {
+                            expect(jumped).toNot(beNil())
+                            expect(jumped).to(equal(queue.current))
+                        }
+                        
+                        it("should move the current index") {
+                            expect(queue.currentIndex).to(equal(1))
+                        }
                     }
                     
-                    it("should have currentIndex 0") {
-                        expect(manager.currentIndex).to(equal(0))
+                    context("then jumping to last item") {
+                        var jumped: Int?
+                        beforeEach {
+                            try? jumped = queue.jump(to: queue.items.count - 1)
+                        }
+                        it("should return the current item") {
+                            expect(jumped).toNot(beNil())
+                            expect(jumped).to(equal(queue.current))
+                        }
+                        
+                        it("should move the current index") {
+                            expect(queue.currentIndex).to(equal(queue.items.count - 1))
+                        }
                     }
                     
-                    it("should have no items") {
-                        expect(manager.items.count).to(equal(0))
+                    context("then jumping to a negative index") {
+                        var jumped: Int?
+                        beforeEach {
+                            jumped = try? queue.jump(to: -1)
+                        }
+                        
+                        it("should not return") {
+                            expect(jumped).to(beNil())
+                        }
+                        
+                        it("should not move the current index") {
+                            expect(queue.currentIndex).to(equal(0))
+                        }
+                    }
+                    
+                    context("then jumping with too large index") {
+                        var jumped: Int?
+                        beforeEach {
+                            jumped = try? queue.jump(to: queue.items.count)
+                        }
+                        it("should not return") {
+                            expect(jumped).to(beNil())
+                        }
+                        
+                        it("should not move the current index") {
+                            expect(queue.currentIndex).to(equal(0))
+                        }
+                    }
+                    
+                    // MARK: - Moving
+                    
+                    context("moving the current item up one") {
+                        var error: Error?
+                        beforeEach {
+                            do {
+                                try queue.moveItem(fromIndex: queue.currentIndex, toIndex: queue.currentIndex + 1)
+                            }
+                            catch let err { error = err }
+                        }
+                        
+                        it("should not throw an error") {
+                            expect(error).to(beNil())
+                        }
+                        it("should change currentIndex") {
+                            expect(queue.currentIndex).to(equal(1))
+                        }
+
+                    }
+                    
+                    context("moving from a negative index") {
+                        var error: Error?
+                        beforeEach {
+                            do {
+                                try queue.moveItem(fromIndex: -1, toIndex: queue.currentIndex + 1)
+                            }
+                            catch let err { error = err }
+                        }
+                        
+                        it("should throw an error") {
+                            expect(error).toNot(beNil())
+                        }
+                    }
+                    
+                    context("moving from a too large index") {
+                        var error: Error?
+                        beforeEach {
+                            do {
+                                try queue.moveItem(fromIndex: queue.items.count, toIndex: queue.currentIndex + 1)
+                            }
+                            catch let err { error = err }
+                        }
+                        
+                        it("should throw an error") {
+                            expect(error).toNot(beNil())
+                        }
+                    }
+                    
+                    context("moving to a negative index") {
+                        var error: Error?
+                        beforeEach {
+                            do {
+                                try queue.moveItem(fromIndex: queue.currentIndex + 1, toIndex: -1)
+                            }
+                            catch let err { error = err }
+                        }
+                        
+                        it("should throw an error") {
+                            expect(error).toNot(beNil())
+                        }
+                    }
+                    
+                    context("moving to a too large index") {
+                        var error: Error?
+                        beforeEach {
+                            do {
+                                try queue.moveItem(fromIndex: queue.currentIndex + 1, toIndex: queue.items.count)
+                            }
+                            catch let err { error = err }
+                        }
+                        
+                        it("should throw an error") {
+                            expect(error).toNot(beNil())
+                        }
+                    }
+                    
+                    context("then moving 2nd to 4th") {
+                        let afterMoving: [Int] = [0, 2, 3, 1, 4, 5, 6]
+                        beforeEach {
+                            try? queue.moveItem(fromIndex: 1, toIndex: 3)
+                        }
+                        
+                        it("should move the item") {
+                            expect(queue.items).to(equal(afterMoving))
+                        }
+                    }
+                    
+                    // MARK: - Clear
+                    
+                    context("when queue is cleared") {
+                        beforeEach {
+                            queue.clearQueue()
+                        }
+                        
+                        it("should have currentIndex -1") {
+                            expect(queue.currentIndex).to(equal(-1))
+                        }
+                        
+                        it("should have no items") {
+                            expect(queue.items.count).to(equal(0))
+                        }
                     }
                 }
             }

--- a/Example/Tests/QueueManagerTests.swift
+++ b/Example/Tests/QueueManagerTests.swift
@@ -150,16 +150,30 @@ class QueueManagerTests: QuickSpec {
                     }
                     
                 }
-                
-                context("then calling previous") {
-                    var previousItem: Int?
+
+                context("then calling next(wrap: true)") {
+                    
+                    var nextIndex: Int?
                     
                     beforeEach {
-                        previousItem = try? manager.previous()
+                        nextIndex = try! manager.next(wrap: true)
                     }
                     
-                    it("should not return") {
-                        expect(previousItem).to(beNil())
+                    it("should wrap to itself") {
+                        expect(nextIndex).to(equal(0))
+                    }
+
+                }
+                
+                context("then calling previous(wrap: true") {
+                    var previousIndex: Int?
+                    
+                    beforeEach {
+                        previousIndex = try? manager.previous(wrap: true)
+                    }
+                    
+                    it("should wrap to itself") {
+                        expect(previousIndex).to(equal(0))
                     }
                 }
                 
@@ -203,18 +217,59 @@ class QueueManagerTests: QuickSpec {
                     it("should have previous items") {
                         expect(manager.previousItems).toNot(beNil())
                     }
-                    
+                                        
                     context("then calling previous") {
-                        var previousItem: Int?
+                        var index: Int?
                         beforeEach {
-                            previousItem = try? manager.previous()
+                            index = try? manager.previous()
                         }
                         it("should return the first item") {
-                            expect(previousItem).toNot(beNil())
-                            expect(previousItem).to(equal(self.dummyItems.first))
+                            expect(index).to(equal(0))
                         }
                         it("should have the previous current item") {
                             expect(manager.current).to(equal(self.dummyItems.first))
+                        }
+                        context("then calling previous at the start of the queue") {
+                            var index: Int?
+                            beforeEach {
+                                index = try? manager.previous()
+                            }
+                            it("should return nil because an error was thrown") {
+                                expect(index).to(beNil())
+                            }
+                        }
+                        context("then calling previous(wrap: true)") {
+                            var index: Int?
+                            beforeEach {
+                                index = try? manager.previous(wrap: true)
+                            }
+                            it("should return the last item") {
+                                expect(index).to(equal(manager.items.count - 1))
+                                expect(manager.currentIndex).to(equal(manager.items.count - 1))
+                                expect(manager.current).to(equal(self.dummyItems.last))
+                            }
+
+                            context("then calling next again at the end of the queue") {
+                                var index: Int?
+                                beforeEach {
+                                    index = try? manager.next()
+                                }
+                                it("should return nil because an error was thrown") {
+                                    expect(index).to(beNil())
+                                }
+                            }
+
+                            context("then calling next(wrap: true)") {
+                                var index: Int?
+                                beforeEach {
+                                    index = try? manager.next(wrap: true)
+                                }
+                                it("should return the first item") {
+                                    expect(index).to(equal(0))
+                                    expect(manager.currentIndex).to(equal(0))
+                                    expect(manager.current).to(equal(self.dummyItems.first))
+                                }
+                            }
                         }
                     }
                     

--- a/Example/Tests/QueuedAudioPlayerTests.swift
+++ b/Example/Tests/QueuedAudioPlayerTests.swift
@@ -307,7 +307,7 @@ class QueuedAudioPlayerTests: QuickSpec {
                                     expect(audioPlayer.nextItems.count).toEventually(equal(0))
                                     expect(audioPlayer.currentIndex).toEventually(equal(1))
                                     expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.paused))
-                                    expect(eventListener.eventResult).toEventually(equal((1, nil)))
+                                    expect(eventListener.eventResult).toEventually(equal((0, 1)))
                                 }
                             }
                         }
@@ -351,7 +351,6 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.nextItems.count).toEventually(equal(1))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
                             }
                         }
 
@@ -458,7 +457,6 @@ class QueuedAudioPlayerTests: QuickSpec {
 
                                 expect(audioPlayer.nextItems.count).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.paused))
-                                expect(eventListener.eventResult).toEventually(equal((0, nil)))
                             }
                         }
 
@@ -487,7 +485,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
 
@@ -499,7 +498,6 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
                             }
                         }
                     }
@@ -521,7 +519,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
 
@@ -536,7 +535,8 @@ class QueuedAudioPlayerTests: QuickSpec {
                                 expect(audioPlayer.currentTime).toEventually(equal(0))
                                 expect(audioPlayer.currentIndex).toEventually(equal(0))
                                 expect(audioPlayer.playerState).toEventually(equal(AudioPlayerState.playing))
-                                expect(eventListener.eventResult).toEventually(equal((0, 0)))
+                                // Because no queueIndex event was emitted, these stay at -1 / -1
+                                expect(eventListener.eventResult).toEventually(equal((-1, -1)))
                             }
                         }
                     }

--- a/SwiftAudioEx/Classes/APError.swift
+++ b/SwiftAudioEx/Classes/APError.swift
@@ -9,20 +9,21 @@ import Foundation
 
 
 public struct APError {
-    
+
     enum LoadError: Error {
         case invalidSourceUrl(String)
     }
-    
+
     enum PlaybackError: Error {
         case noLoadedItem
     }
-    
+
     enum QueueError: Error {
         case noPreviousItem
         case noNextItem
+        case noCurrentItem
         case invalidIndex(index: Int, message: String)
-        case noNextWhenRepeatModeTrack
+        case empty
     }
-    
+
 }

--- a/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
+++ b/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapperProtocol.swift
@@ -13,7 +13,7 @@ protocol AVPlayerWrapperProtocol: AnyObject {
 
     var state: AVPlayerWrapperState { get }
 
-    var playWhenReady: Bool { get }
+    var playWhenReady: Bool { get set }
     
     var currentItem: AVPlayerItem? { get }
     
@@ -54,4 +54,6 @@ protocol AVPlayerWrapperProtocol: AnyObject {
     func load(from url: URL, playWhenReady: Bool, options: [String: Any]?)
     
     func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval?, options: [String: Any]?)
+
+    func reset()
 }

--- a/SwiftAudioEx/Classes/AudioPlayer.swift
+++ b/SwiftAudioEx/Classes/AudioPlayer.swift
@@ -46,8 +46,13 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
 
     // MARK: - Getters from AVPlayerWrapper
 
-    internal var willPlayWhenReady: Bool {
-        wrapper.playWhenReady
+    public var playWhenReady: Bool {
+        get {
+            return wrapper.playWhenReady
+        }
+        set {
+            wrapper.playWhenReady = newValue
+        }
     }
 
     /**
@@ -170,7 +175,7 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
         }
 
         wrapper.load(from: url,
-                     playWhenReady: playWhenReady ?? willPlayWhenReady,
+                     playWhenReady: playWhenReady ?? self.playWhenReady,
                      initialTime: (item as? InitialTiming)?.getInitialTime(),
                      options:(item as? AssetOptionsProviding)?.getAssetOptions())
 

--- a/SwiftAudioEx/Classes/Event.swift
+++ b/SwiftAudioEx/Classes/Event.swift
@@ -18,7 +18,7 @@ extension AudioPlayer {
     public typealias UpdateDurationEventData = Double
     public typealias MetadataEventData = [AVTimedMetadataGroup]
     public typealias DidRecreateAVPlayerEventData = ()
-    public typealias QueueIndexEventData = (previousIndex: Int?, newIndex: Int?)
+    public typealias CurrentItemEventData = (item: AudioItem?, index: Int?)
     
     public struct EventHolder {
         
@@ -73,11 +73,11 @@ extension AudioPlayer {
         public let didRecreateAVPlayer: AudioPlayer.Event<()> = AudioPlayer.Event()
 
         /**
-         Emitted when a new track starts and the queue index changes.
+         Emitted when a track starts to load.
          - Important: Remember to dispatch to the main queue if any UI is updated in the event handler.
          - Note: It is only fired for instances of a QueuedAudioPlayer.
          */
-        public let queueIndex: AudioPlayer.Event<QueueIndexEventData> = AudioPlayer.Event()
+        public let currentItem: AudioPlayer.Event<CurrentItemEventData> = AudioPlayer.Event()
     }
     
     public typealias EventClosure<EventData> = (EventData) -> Void

--- a/SwiftAudioEx/Classes/QueueManager.swift
+++ b/SwiftAudioEx/Classes/QueueManager.swift
@@ -95,8 +95,13 @@ class QueueManager<T> {
         if (currentIndex >= index && self.items.count != 1) { currentIndex += items.count }
     }
 
-    private func skip(direction: Int, wrap: Bool) throws -> T {
-        var index = currentIndex + direction
+    internal enum SkipDirection : Int {
+        case next = 1
+        case previous = -1
+    }
+    
+    private func skip(direction: SkipDirection, wrap: Bool) throws -> T {
+        var index = currentIndex + direction.rawValue
         if (wrap) {
             index = (items.count + index) % items.count;
         }
@@ -119,7 +124,7 @@ class QueueManager<T> {
      */
     @discardableResult
     public func next(wrap: Bool = false) throws -> T {
-        return try skip(direction: 1, wrap: wrap);
+        return try skip(direction: SkipDirection.next, wrap: wrap);
     }
 
     /**
@@ -131,7 +136,7 @@ class QueueManager<T> {
      */
     @discardableResult
     public func previous(wrap: Bool = false) throws -> T {
-        return try skip(direction: -1, wrap: wrap);
+        return try skip(direction: SkipDirection.previous, wrap: wrap);
     }
 
     /**

--- a/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
@@ -12,7 +12,7 @@ import MediaPlayer
  An audio player that can keep track of a queue of AudioItems.
  */
 public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
-    
+
     let queueManager: QueueManager = QueueManager<AudioItem>()
 
     public override init(nowPlayingInfoController: NowPlayingInfoControllerProtocol = NowPlayingInfoController(), remoteCommandController: RemoteCommandController = RemoteCommandController()) {
@@ -22,18 +22,18 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
 
     /// The repeat mode for the queue player.
     public var repeatMode: RepeatMode = .off
-    
+
     public override var currentItem: AudioItem? {
         queueManager.current
     }
-    
+
     /**
      The index of the current item.
      */
     public var currentIndex: Int {
         queueManager.currentIndex
     }
-    
+
      /**
      Stops the player and clears the queue.
      */
@@ -41,149 +41,140 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
         super.stop()
         event.queueIndex.emit(data: (currentIndex, nil))
     }
-    
+
     override func reset() {
         super.reset()
         queueManager.clearQueue()
     }
-    
+
     /**
      All items currently in the queue.
      */
     public var items: [AudioItem] {
         queueManager.items
     }
-    
+
     /**
      The previous items held by the queue.
      */
     public var previousItems: [AudioItem] {
         queueManager.previousItems
     }
-    
+
     /**
      The upcoming items in the queue.
      */
     public var nextItems: [AudioItem] {
         queueManager.nextItems
     }
-    
+
     /**
      Will replace the current item with a new one and load it into the player.
-     
+
      - parameter item: The AudioItem to replace the current item.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: APError.LoadError
      */
-    public override func load(item: AudioItem, playWhenReady: Bool) throws {
-        try super.load(item: item, playWhenReady: playWhenReady)
+    public override func load(item: AudioItem, playWhenReady: Bool? = nil) throws {
+        try super.load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         queueManager.replaceCurrentItem(with: item)
     }
-    
+
     /**
      Add a single item to the queue.
-     
+
      - parameter item: The item to add.
-     - parameter playWhenReady: If the AudioPlayer has no item loaded, it will load the `item`. If this is `true` it will automatically start playback. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func add(item: AudioItem, playWhenReady: Bool = true) throws {
+    public func add(item: AudioItem, playWhenReady: Bool? = nil) throws {
         if currentItem == nil {
             queueManager.addItem(item)
-            try load(item: item, playWhenReady: playWhenReady)
+            try load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
         else {
             queueManager.addItem(item)
         }
     }
-    
+
     /**
      Add items to the queue.
-     
+
      - parameter items: The items to add to the queue.
-     - parameter playWhenReady: If the AudioPlayer has no item loaded, it will load the first item in the list. If this is `true` it will automatically start playback. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func add(items: [AudioItem], playWhenReady: Bool = true) throws {
+    public func add(items: [AudioItem], playWhenReady: Bool? = nil) throws {
         if currentItem == nil {
             queueManager.addItems(items)
-            try load(item: currentItem!, playWhenReady: playWhenReady)
+            try load(item: currentItem!, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
         else {
             queueManager.addItems(items)
         }
     }
-    
+
     public func add(items: [AudioItem], at index: Int) throws {
         try queueManager.addItems(items, at: index)
     }
-    
+
     /**
      Step to the next item in the queue.
-     
+
      - throws: `APError`
      */
     public func next() throws {
-        let shouldPlayWhenReady = (playerState == .loading) ? willPlayWhenReady : [.buffering, .playing].contains(playerState)
-
-        do {
-            let nextItem = try queueManager.next()
-            event.playbackEnd.emit(data: .skippedToNext)
-            try load(item: nextItem, playWhenReady: shouldPlayWhenReady)
-        } catch APError.QueueError.noNextItem  {
-            if repeatMode == .queue {
-                event.playbackEnd.emit(data: .skippedToNext)
-                try jumpToItem(atIndex: 0, playWhenReady: shouldPlayWhenReady)
-            } else {
-                throw APError.QueueError.noNextItem
-            }
-        } catch {
-            throw error
-        }
+        let item = try queueManager.next(wrap: repeatMode == .queue)
+        event.playbackEnd.emit(data: .skippedToNext)
+        try load(item: item)
     }
-    
+
     /**
      Step to the previous item in the queue.
      */
     public func previous() throws {
-        let shouldPlayWhenReady = (playerState == .loading) ? willPlayWhenReady : [.buffering, .playing].contains(playerState)
-
-        let previousItem = try queueManager.previous()
+        let item = try queueManager.previous(wrap: repeatMode == .queue)
         event.playbackEnd.emit(data: .skippedToPrevious)
-        try load(item: previousItem, playWhenReady: shouldPlayWhenReady)
+        try load(item: item)
     }
-    
+
     /**
      Remove an item from the queue.
-     
+
      - parameter index: The index of the item to remove.
      - throws: `APError.QueueError`
      */
     public func removeItem(at index: Int) throws {
         try queueManager.removeItem(at: index)
     }
-    
+
+
     /**
      Jump to a certain item in the queue.
-     
+
      - parameter index: The index of the item to jump to.
-     - parameter playWhenReady: Wether the item should start playing when ready. Default is `true`.
+     - parameter playWhenReady: Optional, whether to start playback when the item is ready.
      - throws: `APError`
      */
-    public func jumpToItem(atIndex index: Int, playWhenReady: Bool = true) throws {
+    public func jumpToItem(atIndex index: Int, playWhenReady: Bool? = nil) throws {
         if (index == currentIndex) {
             seek(to: 0)
-            playWhenReady ? play() : pause()
+            if (playWhenReady == true) {
+                play()
+            } else if (playWhenReady == false) {
+                pause()
+            }
             onCurrentIndexChanged(oldIndex: index, newIndex: index)
         } else {
             let item = try queueManager.jump(to: index)
             event.playbackEnd.emit(data: .jumpedToIndex)
-            try load(item: item, playWhenReady: playWhenReady)
+            try load(item: item, playWhenReady: playWhenReady ?? willPlayWhenReady)
         }
     }
-    
+
     /**
      Move an item in the queue from one position to another.
-     
+
      - parameter fromIndex: The index of the item to move.
      - parameter toIndex: The index to move the item to.
      - throws: `APError.QueueError`
@@ -191,43 +182,31 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
     public func moveItem(fromIndex: Int, toIndex: Int) throws {
         try queueManager.moveItem(fromIndex: fromIndex, toIndex: toIndex)
     }
-    
+
     /**
      Remove all upcoming items, those returned by `next()`
      */
     public func removeUpcomingItems() {
         queueManager.removeUpcomingItems()
     }
-    
+
     /**
      Remove all previous items, those returned by `previous()`
      */
     public func removePreviousItems() {
         queueManager.removePreviousItems()
     }
-    
+
     // MARK: - AVPlayerWrapperDelegate
-    
+
     override func AVWrapperItemDidPlayToEndTime() {
         super.AVWrapperItemDidPlayToEndTime()
-
-        switch repeatMode {
-        case .off:
-            do {
-                let nextItem = try queueManager.next()
-                try load(item: nextItem, playWhenReady: true)
-            } catch {
-                event.queueIndex.emit(data: (currentIndex, nil))
-            }
-        case .track:
-            try? jumpToItem(atIndex: currentIndex, playWhenReady: true)
-        case .queue:
-            do {
-                let nextItem = try queueManager.next()
-                try load(item: nextItem, playWhenReady: true)
-            } catch {
-                try? jumpToItem(atIndex: 0, playWhenReady: true)
-            }
+        if (repeatMode == .track) {
+            seek(to: 0);
+            play()
+        } else {
+            guard let item = try? queueManager.next(wrap: repeatMode == .queue) else { return }
+            try? load(item: item)
         }
     }
 

--- a/SwiftAudioEx/Classes/RemoteCommandController/RemoteCommandController.swift
+++ b/SwiftAudioEx/Classes/RemoteCommandController/RemoteCommandController.swift
@@ -216,7 +216,7 @@ public class RemoteCommandController {
         }
         else if let error = error as? APError.QueueError {
             switch error {
-            case .noNextItem, .noPreviousItem, .invalidIndex(_, _), .noNextWhenRepeatModeTrack:
+            case .empty, .noNextItem, .noPreviousItem, .noCurrentItem, .invalidIndex(_, _):
                 return MPRemoteCommandHandlerStatus.noSuchContent
             }
         }


### PR DESCRIPTION
QueueManager:
- Fixes https://github.com/doublesymmetry/react-native-track-player/issues/1691
- **(breaking)** Make `playWhenReady` optional defaulting to `willPlayWhenReady` in `QueuedAudioPlayer#load`, `QueuedAudioPlayer#add`, `QueuedAudioPlayer#jump` & `AudioPlayer#load`
- **(breaking)** stop `QueuedAudioPlayer#next` and `QueuedAudioPlayer#previous` from (wrongly) mutating `playWhenReady`
- avoid catch logic in `QueuedAudioPlayer#AVWrapperItemDidPlayToEndTime`,  `QueuedAudioPlayer#next()` & `QueuedAudioPlayer#previous()` by adding (optional) wrap parameter to `QueueManager#next` and `QueueManager#previous`
- in QueuedAudioPlayer#AVWrapperItemDidPlayToEndTime when repeat mode is track, we can be assured playWhenReady = true since there is no way `AVWrapperItemDidPlayToEndTime` could be called otherwise. Therefore just seek to the start of the track and play.
- introduce private `skip` helper to `QueueManager` for use in `QueueManager#next` and `QueueManager#previous`
- have currentItem become nil after `clearQueue()`, `removeItem(at index: currentIndex)`
- avoid `moveItem(` from removing and re-adding item, causing it to load again
- avoid throwing in removePreviousItems() and removeNextItems() without queue items
- for methods that need to have tracks in the queue to function, throw new `APError.QueueError.empty` error
- gather invalid index error throwing into `throwIfIndexInvalid(index: Int, name: String = "index”)`
- remove activating of first added item and leave it open for consumers of QueueManager to do so by using onReceivedFirstItem delegate
- throw APError.QueueError.noCurrentItem when calling skip without current item
- allow jumping to current item (which would restart the audio)
- introduce `delegate?.onCurrentItemChanged` to detect switching of current item
- **(breaking)** rename addItems and addItem to add

Event
- **(breaking)** replace queueIndex event with currentItem event with an index parameter

APError
- remove noNextWhenRepeatModeTrack which wasn’t thrown anywhere
- add `.empty` which is thrown by functions expecting the queue not to be empty
- add `.noCurrentItem` which is thrown by methods expecting a current item to be set

QueuedAudioPlayer
- load no longer throws
- move loading / resetting into to QueuedAudioPlayer#onCurrentItemChanged
- move automatic activation of first added item into QueuedAudioPlayer#onReceivedFirstItem

AVPlayerWarapper
- expose AVPlayerWarapper #playWhenReady
- **(breaking)** remove soft parameter of reset
- change player state to idle after reset

AudioPlayer
- hook up AudioPlayer#playWhenReady to AVPlayerWrapper#playWhenReady

QueueManagerTests
- reflect that queue.current stays `nil` when first track is added
- in current item tests, reflect that jump now allows jumping to currentitem
- reflect that removing of `currentItem` is now possible
- add test for removing the `currentItem` when it is the last in the list
- reflect that jumping to the current item no longer throws an error
- reflect that moving the current item no longer throws an error and the currentIndex is changed
- reflect that clearing the queue changes `currentIndex` to `-1`

QueuedAudioPlayerTests
- test that when removing current item, the player becomes idle
- Adjust event listening code to use `audioPlayer.event.currentItem`
-  Adjust tests that expect there to be a currentItem after something has been added, by inserting a context step that does a `jump(to:0)`
- test that calling next or previous without a currentItem throws

Example Player
- Only show play when paused
- Enable queue repeat mode