### PR TITLE
Prevent throwing crash AVPlayerItem addOuput

### DIFF
--- a/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
@@ -75,7 +75,7 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
      - throws: APError.LoadError
      */
     public override func load(item: AudioItem, playWhenReady: Bool) throws {
-        try super.load(item: item, playWhenReady: playWhenReady)
+        try? super.load(item: item, playWhenReady: playWhenReady)
         queueManager.replaceCurrentItem(with: item)
     }
     
@@ -89,7 +89,7 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
     public func add(item: AudioItem, playWhenReady: Bool = true) throws {
         if currentItem == nil {
             queueManager.addItem(item)
-            try load(item: item, playWhenReady: playWhenReady)
+            try? load(item: item, playWhenReady: playWhenReady)
         }
         else {
             queueManager.addItem(item)


### PR DESCRIPTION
Fix crash AVPlayerItem addOuput.
Doesn't expect this crash was thrown in our production code.
*** -[AVPlayerItem addOutput:] Cannot attach an output that is already attached.
Fatal Exception: NSInvalidArgumentException
0  CoreFoundation                 0x9270c __exceptionPreprocess
1  libobjc.A.dylib                0x14f04 objc_exception_throw
2  AVFCore                        0x7e0a4 -[AVPlayerItem(AVPlayerItemOutputs) addOutput:]
3  SwiftAudioEx                   0x14cec closure #1 in closure #1 in AVPlayerWrapper.load(from:playWhenReady:options:) + 211 (AVPlayerWrapper.swift:211)
4  SwiftAudioEx                   0x16928 thunk for @escaping @callee_guaranteed () -> () (<compiler-generated>)
5  libdispatch.dylib              0x63094 _dispatch_call_block_and_release
6  libdispatch.dylib              0x64094 _dispatch_client_callout
7  libdispatch.dylib              0x10d40 _dispatch_main_queue_drain
8  libdispatch.dylib              0x10990 _dispatch_main_queue_callback_4CF$VARIANT$mp
9  CoreFoundation                 0x4dab4 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
10 CoreFoundation                 0xafd8 __CFRunLoopRun
11 CoreFoundation                 0x1dc30 CFRunLoopRunSpecific
12 GraphicsServices               0x1988 GSEventRunModal
13 UIKitCore                      0x4e5c50 -[UIApplication _run]
14 UIKitCore                      0x27f3d0 UIApplicationMain
15 money24h                       0x9854 main + 16 (main.m:16)
16 ???                            0x1045d83d0 (Missing)