### PR TITLE
fix currentTime in now playing center not get updated after seeking

### DIFF
--- a/SwiftAudioEx/Classes/AudioPlayer.swift
+++ b/SwiftAudioEx/Classes/AudioPlayer.swift
@@ -352,7 +352,7 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
     }
     
     func AVWrapper(seekTo seconds: Int, didFinish: Bool) {
-        if !didFinish && automaticallyUpdateNowPlayingInfo {
+        if didFinish && automaticallyUpdateNowPlayingInfo {
             updateNowPlayingCurrentTime(currentTime)
         }
         event.seek.emit(data: (seconds, didFinish))


### PR DESCRIPTION
According to [official document of `seekTo`](https://developer.apple.com/documentation/avfoundation/avplayer/1388493-seektotime?language=objc), `didFinished` is whether the seeking operation finished.