### PR TITLE
fix: #36 - retain playback rate in all situations

### DIFF
--- a/Example/SwiftAudio/AudioController.swift
+++ b/Example/SwiftAudio/AudioController.swift
@@ -11,18 +11,18 @@ import SwiftAudioEx
 
 
 class AudioController {
-
+    
     static let shared = AudioController()
     let player: QueuedAudioPlayer
     let audioSessionController = AudioSessionController.shared
-
+    
     let sources: [AudioItem] = [
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/67b51d90ffddd6bb3f095059997021b589845f81?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "33 \"GOD\"", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/081447adc23dad4f79ba4f1082615d1c56edf5e1?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "8 (circle)", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/6f9999d909b017eabef97234dd7a206355720d9d?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "715 - CRΣΣKS", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/bf9bdd403c67fdbe06a582e7b292487c8cfd1f7e?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "____45_____", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI"))
     ]
-
+    
     init() {
         let controller = RemoteCommandController()
         player = QueuedAudioPlayer(remoteCommandController: controller)
@@ -37,7 +37,6 @@ class AudioController {
         ]
         try? audioSessionController.set(category: .playback)
         try? player.add(items: sources, playWhenReady: false)
-        try? player.rate = 2.0
     }
-
+    
 }

--- a/Example/SwiftAudio/AudioController.swift
+++ b/Example/SwiftAudio/AudioController.swift
@@ -11,18 +11,18 @@ import SwiftAudioEx
 
 
 class AudioController {
-    
+
     static let shared = AudioController()
     let player: QueuedAudioPlayer
     let audioSessionController = AudioSessionController.shared
-    
+
     let sources: [AudioItem] = [
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/67b51d90ffddd6bb3f095059997021b589845f81?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "33 \"GOD\"", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/081447adc23dad4f79ba4f1082615d1c56edf5e1?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "8 (circle)", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/6f9999d909b017eabef97234dd7a206355720d9d?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "715 - CRΣΣKS", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI")),
         DefaultAudioItem(audioUrl: "https://p.scdn.co/mp3-preview/bf9bdd403c67fdbe06a582e7b292487c8cfd1f7e?cid=d8a5ed958d274c2e8ee717e6a4b0971d", artist: "Bon Iver", title: "____45_____", albumTitle: "22, A Million", sourceType: .stream, artwork: #imageLiteral(resourceName: "22AMI"))
     ]
-    
+
     init() {
         let controller = RemoteCommandController()
         player = QueuedAudioPlayer(remoteCommandController: controller)
@@ -37,6 +37,7 @@ class AudioController {
         ]
         try? audioSessionController.set(category: .playback)
         try? player.add(items: sources, playWhenReady: false)
+        try? player.rate = 2.0
     }
-    
+
 }

--- a/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -19,13 +19,13 @@ public enum PlaybackEndedReason: String {
 }
 
 class AVPlayerWrapper: AVPlayerWrapperProtocol {
-    
+
     struct Constants {
         static let assetPlayableKey = "playable"
     }
-    
+
     // MARK: - Properties
-    
+
     fileprivate var avPlayer = AVPlayer()
     private let playerObserver = AVPlayerObserver()
     internal let playerTimeObserver: AVPlayerTimeObserver
@@ -37,11 +37,11 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
 
     /// True when the track was paused for the purpose of switching tracks
     fileprivate var pausedForLoad: Bool = false
-  
-    // We need to track this ourselves, in addition to avPlayer having its rate, because
-    // any call to avPlayer.play() resets its playback rate to 0!
+
+    // We need to track this ourselves, in addition to avPlayer having its rate,
+    // because any call to avPlayer.play() resets its playback rate to 0!
     fileprivate var playRate: Float = 1.0
-    
+
     public init() {
         playerTimeObserver = AVPlayerTimeObserver(periodicObserverTimeInterval: timeEventFrequency.getTime())
         playerTimeObserver.player = avPlayer
@@ -54,10 +54,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
 
         // disabled since we're not making use of video playback
         avPlayer.allowsExternalPlayback = false;
-        
+
         playerTimeObserver.registerForPeriodicTimeEvents()
     }
-    
+
     // MARK: - AVPlayerWrapperProtocol
 
     fileprivate(set) var state: AVPlayerWrapperState = AVPlayerWrapperState.idle {
@@ -96,16 +96,16 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
      True if the last call to load(from:playWhenReady) had playWhenReady=true.
      */
     fileprivate(set) var playWhenReady: Bool = true
-    
+
     var currentItem: AVPlayerItem? {
         avPlayer.currentItem
     }
-    
+
     var currentTime: TimeInterval {
         let seconds = avPlayer.currentTime().seconds
         return seconds.isNaN ? 0 : seconds
     }
-    
+
     var duration: TimeInterval {
         if let seconds = currentItem?.asset.duration.seconds, !seconds.isNaN {
             return seconds
@@ -119,7 +119,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
         return 0.0
     }
-    
+
     var bufferedPosition: TimeInterval {
         currentItem?.loadedTimeRanges.last?.timeRangeValue.end.seconds ?? 0
     }
@@ -137,7 +137,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
 
     weak var delegate: AVPlayerWrapperDelegate? = nil
-    
+
     var bufferDuration: TimeInterval = 0
 
     var timeEventFrequency: TimeEventFrequency = .everySecond {
@@ -145,12 +145,12 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             playerTimeObserver.periodicObserverTimeInterval = timeEventFrequency.getTime()
         }
     }
-    
+
     var volume: Float {
         get { avPlayer.volume }
         set { avPlayer.volume = newValue }
     }
-    
+
     var isMuted: Bool {
         get { avPlayer.isMuted }
         set { avPlayer.isMuted = newValue }
@@ -160,19 +160,22 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         get { avPlayer.automaticallyWaitsToMinimizeStalling }
         set { avPlayer.automaticallyWaitsToMinimizeStalling = newValue }
     }
-    
+
     func play() {
         playWhenReady = true
+
+        // You might be tempted to avPlayer.play() here, but that essentially
+        // sets the rate to 1.0 (https://stackoverflow.com/questions/8688872/).
+        // What you really want to do is to restore the previous play rate.
+        // Bug tracked in #36.
         avPlayer.rate = playRate
-        print("You're playing with new code!");
-        //avPlayer.play()
     }
-    
+
     func pause() {
         playWhenReady = false
         avPlayer.pause()
     }
-    
+
     func togglePlaying() {
         switch avPlayer.timeControlStatus {
         case .playing, .waitingToPlayAtSpecifiedRate:
@@ -183,12 +186,12 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             fatalError("Unknown AVPlayer.timeControlStatus")
         }
     }
-    
+
     func stop() {
         pause()
         reset(soft: false)
     }
-    
+
     func seek(to seconds: TimeInterval) {
        // if the player is loading then we need to defer seeking until it's ready.
        if (state == AVPlayerWrapperState.loading) {
@@ -205,9 +208,9 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
          }
        }
      }
-    
-    
-    
+
+
+
     func load(from url: URL, playWhenReady: Bool, options: [String: Any]? = nil) {
         reset(soft: true)
         self.playWhenReady = playWhenReady
@@ -217,15 +220,15 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         }
 
         pendingAsset = AVURLAsset(url: url, options: options)
-        
+
         if let pendingAsset = pendingAsset {
             state = .loading
             pendingAsset.loadValuesAsynchronously(forKeys: [Constants.assetPlayableKey], completionHandler: { [weak self] in
                 guard let self = self else { return }
-                
+
                 var error: NSError? = nil
                 let status = pendingAsset.statusOfValue(forKey: Constants.assetPlayableKey, error: &error)
-                
+
                 DispatchQueue.main.async {
                     if (pendingAsset != self.pendingAsset) { return; }
                     switch status {
@@ -255,15 +258,15 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
                             }
                         }
                         break
-                        
+
                     case .failed:
                         self.reset(soft: false)
                         self.delegate?.AVWrapper(failedWithError: error)
                         break
-                        
+
                     case .cancelled:
                         break
-                        
+
                     default:
                         break
                     }
@@ -271,7 +274,7 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
             })
         }
     }
-    
+
     func load(from url: URL, playWhenReady: Bool, initialTime: TimeInterval? = nil, options: [String : Any]? = nil) {
         self.initialTime = initialTime
 
@@ -280,9 +283,9 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
 
         self.load(from: url, playWhenReady: playWhenReady, options: options)
     }
-    
+
     // MARK: - Util
-    
+
     private func reset(soft: Bool) {
         playerItemObserver.stopObservingCurrentItem()
         playerTimeObserver.unregisterForBoundaryTimeEvents()
@@ -290,12 +293,12 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
 
         pendingAsset?.cancelLoading()
         pendingAsset = nil
-        
+
         if !soft {
             avPlayer.replaceCurrentItem(with: nil)
         }
     }
-    
+
     /// Will recreate the AVPlayer instance. Used when the current one fails.
     private func recreateAVPlayer() {
         let player = AVPlayer()
@@ -305,17 +308,17 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
         avPlayer = player
         delegate?.AVWrapperDidRecreateAVPlayer()
     }
-    
+
 }
 
 extension AVPlayerWrapper: AVPlayerObserverDelegate {
-    
+
     // MARK: - AVPlayerObserverDelegate
-    
+
     func player(didChangeTimeControlStatus status: AVPlayer.TimeControlStatus) {
         lastPlayerTimeControlStatus = status;
     }
-    
+
     func player(statusDidChange status: AVPlayer.Status) {
         switch status {
         case .readyToPlay:
@@ -328,11 +331,11 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
                 seek(to: initialTime)
             }
             break
-            
+
         case .failed:
             delegate?.AVWrapper(failedWithError: avPlayer.error)
             break
-            
+
         case .unknown:
             break
         @unknown default:
@@ -342,39 +345,39 @@ extension AVPlayerWrapper: AVPlayerObserverDelegate {
 }
 
 extension AVPlayerWrapper: AVPlayerTimeObserverDelegate {
-    
+
     // MARK: - AVPlayerTimeObserverDelegate
-    
+
     func audioDidStart() {
         state = .playing
     }
-    
+
     func timeEvent(time: CMTime) {
         delegate?.AVWrapper(secondsElapsed: time.seconds)
     }
-    
+
 }
 
 extension AVPlayerWrapper: AVPlayerItemNotificationObserverDelegate {
-    
+
     // MARK: - AVPlayerItemNotificationObserverDelegate
-    
+
     func itemDidPlayToEndTime() {
         delegate?.AVWrapperItemDidPlayToEndTime()
     }
-    
+
 }
 
 extension AVPlayerWrapper: AVPlayerItemObserverDelegate {
-    
+
     // MARK: - AVPlayerItemObserverDelegate
-    
+
     func item(didUpdateDuration duration: Double) {
         delegate?.AVWrapper(didUpdateDuration: duration)
     }
-    
+
     func item(didReceiveMetadata metadata: [AVTimedMetadataGroup]) {
         delegate?.AVWrapper(didReceiveMetadata: metadata)
     }
-    
+
 }

--- a/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/SwiftAudioEx/Classes/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -37,6 +37,10 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
 
     /// True when the track was paused for the purpose of switching tracks
     fileprivate var pausedForLoad: Bool = false
+  
+    // We need to track this ourselves, in addition to avPlayer having its rate, because
+    // any call to avPlayer.play() resets its playback rate to 0!
+    fileprivate var playRate: Float = 1.0
     
     public init() {
         playerTimeObserver = AVPlayerTimeObserver(periodicObserverTimeInterval: timeEventFrequency.getTime())
@@ -125,8 +129,11 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     }
 
     var rate: Float {
-        get { avPlayer.rate }
-        set { avPlayer.rate = newValue }
+        get { playRate }
+        set {
+          playRate = newValue
+          avPlayer.rate = newValue
+        }
     }
 
     weak var delegate: AVPlayerWrapperDelegate? = nil
@@ -156,7 +163,9 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     
     func play() {
         playWhenReady = true
-        avPlayer.play()
+        avPlayer.rate = playRate
+        print("You're playing with new code!");
+        //avPlayer.play()
     }
     
     func pause() {


### PR DESCRIPTION
The call to `avPlayer.play()` resets the playback rate to 1.0 (according to official docs, and referred to [here](https://stackoverflow.com/questions/8688872/)). People have been saying in `react-native-track-player` for years that this has been happening (e.g. https://github.com/doublesymmetry/react-native-track-player/issues/614).

This fixes that. We now store an internal expected playback rate (`playRate`), and instead of calling `avPlayer.play()`, we simply restore the rate to what the caller expects.

Tested this by using a bare-minimum [repro project](https://github.com/SuperphonicHub/TrackPlayerRateExample) and modifying the Swift package directly to verify that the bug is fixed.

Sorry about the whitespace removal... I think that's my VS Code talking.