### PR TITLE
fix: #42 - update current item correctly upon removal

### DIFF
--- a/SwiftAudioEx/Classes/QueueManager.swift
+++ b/SwiftAudioEx/Classes/QueueManager.swift
@@ -223,9 +223,15 @@ class QueueManager<T> {
         try throwIfIndexInvalid(index: index)
         let result = items.remove(at: index)
 
-        mutateCurrentIndex(index: index == currentIndex && items.count > 0
-           ? currentIndex % items.count : -1
-        )
+        // #42 - if you've removed the current item, make sure you treat it as
+        // if the current item changed. mutateCurrentIndex doesn't do so.
+        if (index == currentIndex) {
+            delegate?.onCurrentItemChanged()
+        } else {
+            mutateCurrentIndex(index:
+                items.count > 0 ? currentIndex % items.count : -1
+            )
+        }
 
         return result;
     }


### PR DESCRIPTION
The previous code used to not update the current item correctly when the current item was removed. This led to cases where you would remove an item, then act on what you thought was the new item (e.g. by trying to get its duration, by playing it, etc.) when AVPlayer was still operating on the old item.

This fixes that by sending the right delegate notification when the current item is the one being removed.

Tested by operating on this through react-native-track-player's example app to verify fixed behavior, as well as by running the new code in my production app.