### PR TITLE
Fix/queue manager

### DIFF
--- a/Example/Tests/QueueManagerTests.swift
+++ b/Example/Tests/QueueManagerTests.swift
@@ -149,8 +149,31 @@ class QueueManagerTests: QuickSpec {
                         queue.replaceCurrentItem(with: 1)
                     }
                     it("should have added an item and jumped to it") {
+                        expect(queue.items.count).to(equal(2))
                         expect(queue.current).to(equal(1))
                         expect(queue.currentIndex).to(equal(1))
+                    }
+
+                    context("then calling next") {
+                        var item: Int?
+                        beforeEach {
+                            item = queue.next()
+                        }
+                        
+                        it("should noop") {
+                            expect(item).to(equal(1))
+                        }
+                    }
+
+                    context("then calling previous") {
+                        var item: Int?
+                        beforeEach {
+                            item = queue.previous()
+                        }
+                        
+                        it("should go back to the first") {
+                            expect(item).to(equal(0))
+                        }
                     }
                 }
                 
@@ -161,7 +184,7 @@ class QueueManagerTests: QuickSpec {
                     }
                     
                     it("should noop") {
-                        expect(item).to(equal(0))
+                        expect(item).to(beNil())
                     }
                 }
 
@@ -172,7 +195,7 @@ class QueueManagerTests: QuickSpec {
                     }
                     
                     it("should noop") {
-                        expect(item).to(equal(0))
+                        expect(item).to(beNil())
                     }
                 }
                 
@@ -228,6 +251,7 @@ class QueueManagerTests: QuickSpec {
                     beforeEach {
                         try! queue.jump(to: 0)
                     }
+
                     context("then calling next") {
                         var nextItem: Int?
                         beforeEach {
@@ -352,12 +376,16 @@ class QueueManagerTests: QuickSpec {
                             removed = try? queue.removeItem(at: initialCurrentIndex - 1)
                         }
 
-                        it("should remove an item") {
-                            expect(removed).toNot(beNil())
+                        it("should remove the first item") {
+                            expect(removed).to(equal(0))
                         }
 
-                        it("should decrement the currentIndex") {
-                            expect(queue.currentIndex).to(equal(initialCurrentIndex - 1))
+                        it("should have set the initial current index to 1") {
+                            expect(initialCurrentIndex).to(equal(1))
+                        }
+                        
+                        it("should decremented the currentIndex from 1 to 0") {
+                            expect(queue.currentIndex).to(equal(0))
                         }
                     }
                     

--- a/Example/Tests/QueueManagerTests.swift
+++ b/Example/Tests/QueueManagerTests.swift
@@ -344,22 +344,20 @@ class QueueManagerTests: QuickSpec {
                     // MARK: - Removal
                     
                     context("then removing a item with index less than currentIndex") {
+                        var removed: Int?
+                        var initialCurrentIndex: Int!
                         beforeEach {
-                            var removed: Int?
-                            var initialCurrentIndex: Int!
-                            beforeEach {
-                                let _ = try? queue.jump(to: 3)
-                                initialCurrentIndex = queue.currentIndex
-                                removed = try? queue.removeItem(at: initialCurrentIndex - 1)
-                            }
-                            
-                            it("should remove an item") {
-                                expect(removed).toNot(beNil())
-                            }
-                            
-                            it("should decrement the currentIndex") {
-                                expect(queue.currentIndex).to(equal(initialCurrentIndex - 1))
-                            }
+                            let _ = try? queue.jump(to: 1)
+                            initialCurrentIndex = queue.currentIndex
+                            removed = try? queue.removeItem(at: initialCurrentIndex - 1)
+                        }
+
+                        it("should remove an item") {
+                            expect(removed).toNot(beNil())
+                        }
+
+                        it("should decrement the currentIndex") {
+                            expect(queue.currentIndex).to(equal(initialCurrentIndex - 1))
                         }
                     }
                     

--- a/Example/Tests/QueuedAudioPlayerTests.swift
+++ b/Example/Tests/QueuedAudioPlayerTests.swift
@@ -264,10 +264,23 @@ class QueuedAudioPlayerTests: QuickSpec {
 
                 context("when adding multiple items") {
                     beforeEach {
-                        audioPlayer.add(items: [FiveSecondSource.getAudioItem(), FiveSecondSource.getAudioItem()], playWhenReady: false)
+                        audioPlayer.add(items: [FiveSecondSource.getAudioItem(), ShortSource.getAudioItem()], playWhenReady: false)
                     }
-                    it("should not be nil") {
+                    it("currentItem should not be nil") {
                         expect(audioPlayer.currentItem).toNot(beNil())
+                    }
+
+                    it("currentIndex should be 0") {
+                        expect(audioPlayer.currentIndex).to(equal(0))
+                    }
+
+                    context("then removing the first item") {
+                        it("the current item should now be what was previously the second item") {
+                            try? audioPlayer.removeItem(at: 0)
+                            expect (audioPlayer.items.count).to(equal(1))
+                            expect (audioPlayer.currentItem?.getSourceUrl()).to(equal(ShortSource.getAudioItem().getSourceUrl()))
+                            expect(audioPlayer.currentItem?.getSourceUrl()).to(equal(ShortSource.getAudioItem().getSourceUrl()))
+                        }
                     }
                 }
             }

--- a/SwiftAudioEx/Classes/QueueManager.swift
+++ b/SwiftAudioEx/Classes/QueueManager.swift
@@ -223,9 +223,11 @@ class QueueManager<T> {
         try throwIfIndexInvalid(index: index)
         let result = items.remove(at: index)
 
-        mutateCurrentIndex(index: index == currentIndex && items.count > 0
-           ? currentIndex % items.count : -1
-        )
+        if index == currentIndex {
+            mutateCurrentIndex(index: items.count > 0 ? currentIndex % items.count : -1)
+        } else if index < currentIndex {
+            mutateCurrentIndex(index: currentIndex - 1)
+        }
 
         return result;
     }


### PR DESCRIPTION
Pulls in commit from https://github.com/doublesymmetry/SwiftAudioEx/pull/41

and adds:
- avoid calling delegate?.onSkippedToSameCurrentItem() when the current index becomes one less due to a track before it being removed (the root cause of what https://github.com/doublesymmetry/SwiftAudioEx/pull/43 fixes)
- avoid calling onCurrentItemChanged unnecessarily in skip
- move onSkippedToSameCurrentItem() call into skip & jump
- fix a few tests