### PR TITLE
fix: repeat mode

### DIFF
--- a/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
+++ b/SwiftAudioEx/Classes/QueuedAudioPlayer.swift
@@ -193,8 +193,8 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
     override func AVWrapperItemDidPlayToEndTime() {
         event.playbackEnd.emit(data: .playedUntilEnd)
         if (repeatMode == .track) {
-            // quick workaround for race condition - place call bottom of call stack
-            DispatchQueue.main.async { [weak self] in self?.replay() }
+            // quick workaround for race condition - schedule a call after 2 frames
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.016 * 2) { [weak self] in self?.replay() }
         } else if (repeatMode == .queue) {
             _ = queue.next(wrap: true)
         } else if (currentIndex != items.count - 1) {


### PR DESCRIPTION
Fixes https://github.com/doublesymmetry/react-native-track-player/issues/2070

Race condition happens between:

```swift
private func handleTimeControlStatusChange(_ change: [NSKeyValueChangeKey: Any]?) {
        let status: AVPlayer.TimeControlStatus
        if let statusNumber = change?[.newKey] as? NSNumber {
            status = AVPlayer.TimeControlStatus(rawValue: statusNumber.intValue)!
            print("PAUSE \(Date().currentTimeMillis()) \(status)") // <-- newly added code
            delegate?.player(didChangeTimeControlStatus: status)
        }
    }
```

and

```swift
func replay() {
    seek(to: 0);
    print("PLAY \(Date().currentTimeMillis())") // <-- newly added code
    play()
}
```

And when track is getting paused it produces following output in console:

![image](https://github.com/doublesymmetry/SwiftAudioEx/assets/22820318/b7e451f1-3714-43ca-9265-f013040488e3)

or

![image](https://github.com/doublesymmetry/SwiftAudioEx/assets/22820318/1a966fa5-8b4a-4ffc-81fd-dcee108ab39a)


As you can see we call `play` at `...149` (picture number 1) and after that we receive many calls to `handleTimeControlStatusChange` which changes `playWhenReady` to `false`.

In this PR I'm simply following previous approach added in https://github.com/doublesymmetry/SwiftAudioEx/commit/bfe5851dc4b26ebdddfff69aeb4386e818562f6c - just schedule a call 2 frames later (I gathered some data and it seems like call to `handleTimeControlStatusChange` happen in range 20-23ms, so it's definitely more than one frame (16-17ms), but less than 2 frames (32-34ms), so I dispatch code after 32ms 🙂

I don't like the current solution (though it fixes the problem), and I thought about preventing of setting `playWhenReady` if repeat mode is `track`:

```diff
func player(didChangeTimeControlStatus status: AVPlayer.TimeControlStatus) {
        switch status {
        case .paused:
            let state = self.state
            if self.asset == nil && state != .stopped {
                self.state = .idle
            } else if (state != .failed && state != .stopped) {
                // Playback may have become paused externally for example due to a bluetooth device disconnecting:
                if (self.playWhenReady) {
                    // Only if we are not on the boundaries of the track, otherwise itemDidPlayToEndTime will handle it instead.
-                    if (self.currentTime > 0 && self.currentTime < self.duration) {
+                    if (self.currentTime > 0 && self.currentTime < self.duration && self.repeatMode != .track) {
                        self.playWhenReady = false;
                    }
                } else {
                    self.state = .paused
                }
            }
```

But it seems like `AVPlayerWrapper` doesn't know anything about `repeatMode` (and I think according to its name shouldn't?), so I was afraid to make such changes.

Anyway I'll be happy to hear your suggestions on how it can be improved!