### PR TITLE
Avoid emitting empty metadata.

### DIFF
--- a/SwiftAudioEx/Classes/Observer/AVPlayerItemObserver.swift
+++ b/SwiftAudioEx/Classes/Observer/AVPlayerItemObserver.swift
@@ -114,6 +114,9 @@ class AVPlayerItemObserver: NSObject {
 
 extension AVPlayerItemObserver: AVPlayerItemMetadataOutputPushDelegate {
     func metadataOutput(_ output: AVPlayerItemMetadataOutput, didOutputTimedMetadataGroups groups: [AVTimedMetadataGroup], from track: AVPlayerItemTrack?) {
-        delegate?.item(didReceiveTimedMetadata: groups)
+        let groupsWithMetadata = groups.filter { !$0.items.isEmpty }
+        if !groupsWithMetadata.isEmpty {
+            delegate?.item(didReceiveTimedMetadata: groupsWithMetadata)
+        }
     }
 }


### PR DESCRIPTION
Using rntp, I was seeing empty values for Event.MetadataTimedReceived like: `{ "raw": [] }`. This commit filters out these empty metadata groups.