### PR TITLE
fix(notification): update rate in notification when rate changes

### DIFF
--- a/SwiftAudioEx/Classes/AudioPlayer.swift
+++ b/SwiftAudioEx/Classes/AudioPlayer.swift
@@ -137,7 +137,12 @@ public class AudioPlayer: AVPlayerWrapperDelegate {
 
     public var rate: Float {
         get { wrapper.rate }
-        set { wrapper.rate = newValue }
+        set {
+            wrapper.rate = newValue
+            if (automaticallyUpdateNowPlayingInfo) {
+                updateNowPlayingPlaybackValues()
+            }
+        }
     }
 
     // MARK: - Init


### PR DESCRIPTION
Fixes issue where if you update the rate, the command center wouldn't update until you pause (or change state in some way)