### PR TITLE
Fix crash on attaching metadata output

### DIFF
--- a/Sources/SwiftAudioEx/Observer/AVPlayerItemObserver.swift
+++ b/Sources/SwiftAudioEx/Observer/AVPlayerItemObserver.swift
@@ -71,7 +71,7 @@ class AVPlayerItemObserver: NSObject {
         // We must slightly delay adding the metadata output due to the fact that
         // stop observation is not a synchronous action and metadataOutput may not
         // be removed from last item before we try to attach it to a new one.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.001) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
             guard let `self` = self else { return }
             item.add(self.metadataOutput)
         }


### PR DESCRIPTION
The issue: https://github.com/doublesymmetry/react-native-track-player/issues/1818
The previous fix: https://github.com/doublesymmetry/SwiftAudioEx/pull/68

The previous attempt to fix it was not ideal cause we don't know the exact observation removal time.

My approach:
- Deferred Addition of Metadata Output
- Each observed item now gets a fresh instance of metadata output for cleaner management.
- Added a check to ensure safe removal of metadata output from the observing item.