### PR TITLE
fix: broken progress bar after repeat

### DIFF
--- a/Sources/SwiftAudioEx/QueuedAudioPlayer.swift
+++ b/Sources/SwiftAudioEx/QueuedAudioPlayer.swift
@@ -193,6 +193,8 @@ public class QueuedAudioPlayer: AudioPlayer, QueueManagerDelegate {
     override func AVWrapperItemDidPlayToEndTime() {
         event.playbackEnd.emit(data: .playedUntilEnd)
         if (repeatMode == .track) {
+            self.pause()
+
             // quick workaround for race condition - schedule a call after 2 frames
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.016 * 2) { [weak self] in self?.replay() }
         } else if (repeatMode == .queue) {


### PR DESCRIPTION
To reproduce the issue you need:
- to have a single track in queue
- play this track
- activate `repeat` while track is playing (in `options` select `track`)
- do not move slider - just wait for end of track 😊 

> [!IMPORTANT]
> The issue is not reproducible in default example app - for some reasons it happens only with specific tracks, below I added necessary changes that needs to be made in RNTP example app.

A queue (`playlist.json`):

```json
[
  {
    "url": "https://assets.contentstack.io/v3/assets/blt464811b872cc339a/blt5224b03977c199ae/639d58298f1f170dcb412a75/en-koa-3-6-daily-mood-boost_2022-09-05_03_31_39.m4a",
    "title": "Longing",
    "artist": "David Chavez",
    "artwork": "https://rntp.dev/example/Longing.jpeg",
    "duration": 167
  }
]
```

`QueueInitialTracksService.ts`:

```ts
import TrackPlayer, { Track } from 'react-native-track-player';

import playlistData from '../assets/data/playlist.json';
// @ts-expect-error – sure we can import this
import localTrack from '../assets/resources/pure.m4a';
// @ts-expect-error – sure we can import this
import localArtwork from '../assets/resources/artwork.jpg';

export const QueueInitialTracksService = async (): Promise<void> => {
  await TrackPlayer.add([...(playlistData as Track[])]);
};
```

|Before|After|
|-------|-----|
|![Screenshot 2024-03-01 at 9 40 37 AM](https://github.com/doublesymmetry/SwiftAudioEx/assets/22820318/b356a7af-4334-4718-a565-2d14351a79b8)|![Screenshot 2024-03-01 at 9 37 03 AM](https://github.com/doublesymmetry/SwiftAudioEx/assets/22820318/37379066-8090-407e-933a-823b7bc577fe)|