### PR TITLE
Fix Adding tracks before index in queue

### DIFF
--- a/Sources/SwiftAudioEx/QueueManager.swift
+++ b/Sources/SwiftAudioEx/QueueManager.swift
@@ -145,7 +145,7 @@ class QueueManager<T> {
                 throw AudioPlayerError.QueueError.invalidIndex(index: index, message: "Index to insert at has to be non-negative and equal to or smaller than the number of items: (\(items.count))")
             }
             // Correct index when items were inserted in front of it:
-            if (self.items.count > 1 && currentIndex >= index) {
+            if (self.items.count > 0 && currentIndex >= index) {
                 currentIndex += items.count
             }
             self.items.insert(contentsOf: items, at: index)


### PR DESCRIPTION
Our team was using the react-native-track-player and found that when trying to add tracks before an index, the queue would fail. This was particularly true when just adding one single track. Through that, we diagnosed the problem in the single comparison that we noted. 

React-Native Function to replicate problem:
```
async function playTrackandQueuePlaylist(track, playlist) {
      await TrackPlayer.add(track);
      await TrackPlayer.play();
      if (playlist){
             let currentTrackIndex = playlist.findIndex((track) => track.track_id === currentTrack?.track_id);
             const beforeTracks = aiTracks.slice(0, currentTrackIndex);
             const afterTracks = aiTracks.slice(currentTrackIndex + 1);
             TrackPlayer.add(beforeTracks, 0);
             TrackPlayer.add(afterTracks);
      }
}
```

Running this code and tracing through the swift code would show you that the items are not being added when beforeTracks has a size of one. It would work fine when handling more than 2 tracks, but failed in this edge case. We solved it with full functionality when made the comparison to 0 instead of 1.

Seems super silly to PR this, but this one bug had me stuck trying to get our queue manager working for 4 hours, and is the biggest pain in the butt.
