### PR TITLE
Potential Fix for  -[AVPlayerItem addOutput:] Cannot attach an output that is already attached or nil output

### DIFF
--- a/Example/SwiftAudio.xcodeproj/project.pbxproj
+++ b/Example/SwiftAudio.xcodeproj/project.pbxproj
@@ -301,7 +301,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftAudio/Preview Content\"";
-				DEVELOPMENT_TEAM = 7U2TUNKNQX;
+				DEVELOPMENT_TEAM = KU6AJRLF6T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -320,7 +320,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.doublesymmetry.SwiftAudio;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fountain.SwiftAudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -339,7 +339,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"SwiftAudio/Preview Content\"";
-				DEVELOPMENT_TEAM = 7U2TUNKNQX;
+				DEVELOPMENT_TEAM = KU6AJRLF6T;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -358,7 +358,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.doublesymmetry.SwiftAudio;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fountain.SwiftAudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/Sources/SwiftAudioEx/AVPlayerWrapper/AVPlayerWrapper.swift
+++ b/Sources/SwiftAudioEx/AVPlayerWrapper/AVPlayerWrapper.swift
@@ -373,12 +373,17 @@ class AVPlayerWrapper: AVPlayerWrapperProtocol {
     // MARK: - Util
 
     private func clearCurrentItem() {
-        guard let asset = asset else { return }
-        stopObservingAVPlayerItem()
-        
-        asset.cancelLoading()
-        self.asset = nil
-        
+       if (self.asset != nil) {
+              self.asset?.cancelLoading()
+              self.asset = nil
+       }
+        stopObservingAVPlayerItem()  
+
+        guard let currentItem = avPlayer.currentItem else { return }
+        // Remove all outputs from the current item
+        currentItem.outputs.forEach { output in
+            currentItem.remove(output)
+        }  
         avPlayer.replaceCurrentItem(with: nil)
     }
     


### PR DESCRIPTION
Changes:

No longer return early if asset is null. instead if the asset is not null we clean up the asset
We also now iterate through the outputs and remove them

